### PR TITLE
Unit test fixes

### DIFF
--- a/src/test/java/org/whispersystems/textsecuregcm/tests/controllers/KeyControllerTest.java
+++ b/src/test/java/org/whispersystems/textsecuregcm/tests/controllers/KeyControllerTest.java
@@ -146,7 +146,7 @@ public class KeyControllerTest {
                                           AuthHelper.getAuthHeader(AuthHelper.VALID_NUMBER, AuthHelper.VALID_PASSWORD))
                                   .get(PreKeyCount.class);
 
-    assertThat(result.getCount() == 4);
+    assertThat(result.getCount()).isEqualTo(4);
 
     verify(keys).getCount(eq(AuthHelper.VALID_NUMBER), eq(1L));
   }
@@ -160,7 +160,7 @@ public class KeyControllerTest {
                                           AuthHelper.getAuthHeader(AuthHelper.VALID_NUMBER, AuthHelper.VALID_PASSWORD))
                                   .get(PreKeyCount.class);
 
-    assertThat(result.getCount() == 4);
+    assertThat(result.getCount()).isEqualTo(4);
 
     verify(keys).getCount(eq(AuthHelper.VALID_NUMBER), eq(1L));
   }
@@ -173,7 +173,7 @@ public class KeyControllerTest {
                                    .header("Authorization", AuthHelper.getAuthHeader(AuthHelper.VALID_NUMBER, AuthHelper.VALID_PASSWORD))
                                    .get(SignedPreKey.class);
 
-    assertThat(result.equals(SAMPLE_SIGNED_KEY));
+    assertThat(result).isEqualTo(SAMPLE_SIGNED_KEY);
   }
 
   @Test
@@ -185,7 +185,7 @@ public class KeyControllerTest {
                                        .header("Authorization", AuthHelper.getAuthHeader(AuthHelper.VALID_NUMBER, AuthHelper.VALID_PASSWORD))
                                        .put(Entity.entity(test, MediaType.APPLICATION_JSON_TYPE));
 
-    assertThat(response.getStatus() == 204);
+    assertThat(response.getStatus()).isEqualTo(204);
 
     verify(AuthHelper.VALID_DEVICE).setSignedPreKey(eq(test));
     verify(accounts).update(eq(AuthHelper.VALID_ACCOUNT));
@@ -410,13 +410,13 @@ public class KeyControllerTest {
     verify(keys).store(eq(AuthHelper.VALID_NUMBER), eq(1L), listCaptor.capture(), lastResortCaptor.capture());
 
     List<PreKeyV1> capturedList = listCaptor.getValue();
-    assertThat(capturedList.size() == 1);
-    assertThat(capturedList.get(0).getIdentityKey().equals("foobarbaz"));
-    assertThat(capturedList.get(0).getKeyId() == 31337);
-    assertThat(capturedList.get(0).getPublicKey().equals("foobar"));
+    assertThat(capturedList.size()).isEqualTo(1);
+    assertThat(capturedList.get(0).getIdentityKey()).isEqualTo("foobarbaz");
+    assertThat(capturedList.get(0).getKeyId()).isEqualTo(31337);
+    assertThat(capturedList.get(0).getPublicKey()).isEqualTo("foobar");
 
-    assertThat(lastResortCaptor.getValue().getPublicKey().equals("fooz"));
-    assertThat(lastResortCaptor.getValue().getIdentityKey().equals("foobarbaz"));
+    assertThat(lastResortCaptor.getValue().getPublicKey()).isEqualTo("fooz");
+    assertThat(lastResortCaptor.getValue().getIdentityKey()).isEqualTo("foobarbaz");
 
     verify(AuthHelper.VALID_ACCOUNT).setIdentityKey(eq("foobarbaz"));
     verify(accounts).update(AuthHelper.VALID_ACCOUNT);
@@ -448,9 +448,9 @@ public class KeyControllerTest {
     verify(keys).store(eq(AuthHelper.VALID_NUMBER), eq(1L), listCaptor.capture(), eq(lastResortKey));
 
     List<PreKeyV2> capturedList = listCaptor.getValue();
-    assertThat(capturedList.size() == 1);
-    assertThat(capturedList.get(0).getKeyId() == 31337);
-    assertThat(capturedList.get(0).getPublicKey().equals("foobar"));
+    assertThat(capturedList.size()).isEqualTo(1);
+    assertThat(capturedList.get(0).getKeyId()).isEqualTo(31337);
+    assertThat(capturedList.get(0).getPublicKey()).isEqualTo("foobar");
 
     verify(AuthHelper.VALID_ACCOUNT).setIdentityKey(eq("barbar"));
     verify(AuthHelper.VALID_DEVICE).setSignedPreKey(eq(signedPreKey));

--- a/src/test/java/org/whispersystems/textsecuregcm/tests/controllers/KeyControllerTest.java
+++ b/src/test/java/org/whispersystems/textsecuregcm/tests/controllers/KeyControllerTest.java
@@ -133,7 +133,7 @@ public class KeyControllerTest {
 
     when(keys.getCount(eq(AuthHelper.VALID_NUMBER), eq(1L))).thenReturn(5);
 
-    when(AuthHelper.VALID_DEVICE.getSignedPreKey()).thenReturn(new SignedPreKey(89898, "zoofarb", "sigvalid"));
+    when(AuthHelper.VALID_DEVICE.getSignedPreKey()).thenReturn(SAMPLE_SIGNED_KEY);
     when(AuthHelper.VALID_ACCOUNT.getIdentityKey()).thenReturn(null);
   }
 


### PR DESCRIPTION
I ran [pitest](http://pitest.org) and found two things:
1. An order dependency in the WebsocketControllerTest due to the static fields
2. Some assertThat lines that were not actually asserting anything

Using the pitest results, I added some more assertions and tests - mostly for error cases - in a [branch](https://github.com/mdietz198/TextSecure-Server/tree/add-pitest). If that help is appreciated, I can keep adding some more coverage and make another pull request. If not, no worries. If you're more interested in contributions to the client, I'd be happy to give that a shot.
