### PR TITLE
Allow configuring the S3 endpoint, region, and other parameters

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-s3</artifactId>
-            <version>1.10.6</version>
+            <version>1.11.86</version>
         </dependency>
         <dependency>
             <groupId>com.google.protobuf</groupId>

--- a/src/main/java/org/whispersystems/textsecuregcm/configuration/S3Configuration.java
+++ b/src/main/java/org/whispersystems/textsecuregcm/configuration/S3Configuration.java
@@ -33,6 +33,18 @@ public class S3Configuration {
   @JsonProperty
   private String attachmentsBucket;
 
+  @JsonProperty
+  private String endpoint;
+
+  @JsonProperty
+  private String region;
+
+  @JsonProperty
+  private String signerAlgorithm;
+
+  @JsonProperty
+  private Boolean pathStyleAccess;
+
   public String getAccessKey() {
     return accessKey;
   }
@@ -44,4 +56,21 @@ public class S3Configuration {
   public String getAttachmentsBucket() {
     return attachmentsBucket;
   }
+
+  public String getEndpoint() {
+    return endpoint;
+  }
+
+  public String getRegion() {
+    return region;
+  }
+
+  public String getSignerAlgorithm() {
+    return signerAlgorithm;
+  }
+
+  public Boolean getPathStyleAccess() {
+    return pathStyleAccess;
+  }
+
 }

--- a/src/main/java/org/whispersystems/textsecuregcm/util/UrlSigner.java
+++ b/src/main/java/org/whispersystems/textsecuregcm/util/UrlSigner.java
@@ -68,9 +68,7 @@ public class UrlSigner {
 
     if (region != null && (endpoint == null || endpoint.isEmpty())) {
       clientBuilder.setRegion(region);
-    }
-
-    if (endpoint != null && !endpoint.isEmpty()) {
+    } else if (endpoint != null && !endpoint.isEmpty()) {
       // region can be null or empty
       AwsClientBuilder.EndpointConfiguration endpointConfiguration =
           new AwsClientBuilder.EndpointConfiguration(endpoint, region);

--- a/src/main/java/org/whispersystems/textsecuregcm/util/UrlSigner.java
+++ b/src/main/java/org/whispersystems/textsecuregcm/util/UrlSigner.java
@@ -55,7 +55,7 @@ public class UrlSigner {
     AmazonS3ClientBuilder clientBuilder = AmazonS3ClientBuilder.standard();
     ClientConfiguration clientConfiguration = new ClientConfiguration();
 
-    if (signer != null) {
+    if (signer != null && !signer.isEmpty()) {
       clientConfiguration.setSignerOverride(signer);
       clientBuilder.setClientConfiguration(clientConfiguration);
     }
@@ -70,8 +70,8 @@ public class UrlSigner {
       clientBuilder.setRegion(region);
     }
 
-    if (endpoint != null) {
-      // region can be null
+    if (endpoint != null && !endpoint.isEmpty()) {
+      // region can be null or empty
       AwsClientBuilder.EndpointConfiguration endpointConfiguration =
           new AwsClientBuilder.EndpointConfiguration(endpoint, region);
       clientBuilder.setEndpointConfiguration(endpointConfiguration);


### PR DESCRIPTION
In the Amazon S3 yml configuration read and use the following parameters, here shown with sample values:

```
s3:
  endpoint: https://my-host.net/
  region: us-east-1
  pathStyleAccess: true
  signerAlgorithm: AWSS3V4SignerType
```

Being able to specify them allows to self-host an S3 service. The aws-sdk has been updated too, removing the calls to some deprecated methods.