### PR TITLE
Add support for numbers from Samoa, Andorra, Greenland, and Suriname

### DIFF
--- a/src/main/java/org/whispersystems/textsecuregcm/util/Util.java
+++ b/src/main/java/org/whispersystems/textsecuregcm/util/Util.java
@@ -44,10 +44,14 @@ public class Util {
 
   public static boolean isValidNumber(String number) {
     return number.matches("^\\+[0-9]{10,}")  ||
-           number.matches("^\\+298[0-9]{6}") ||
-           number.matches("^\\+240[0-9]{6}") ||
-           number.matches("^\\+687[0-9]{6}") ||
-           number.matches("^\\+689[0-9]{6}");
+           number.matches("^\\+240[0-9]{6}") ||  // Equatorial Guinea
+           number.matches("^\\+298[0-9]{6}") ||  // Faroe Islands      
+           number.matches("^\\+299[0-9]{6}") ||  // Greenland
+           number.matches("^\\+376[0-9]{6}") ||  // Andorra
+           number.matches("^\\+597[0-9]{6}") ||  // Suriname
+           number.matches("^\\+685[0-9]{5}") ||  // Samoa
+           number.matches("^\\+687[0-9]{6}") ||  // New Caledonia
+           number.matches("^\\+689[0-9]{6}");    // French Polynesia
   }
 
   public static String encodeFormParams(Map<String, String> params) {


### PR DESCRIPTION
Samoa*: +685 XXXXX
Andorra: +376 X XXXXX
Greenland: +299 XX XX XX
Suriname: +597 XXX XXX

*total of 8 digits

Users in Andorra and Greenland have been writing in that the verification code does not arrive. Previously, this [change was made in another library](https://github.com/signalapp/libsignal-service-java/pull/17) but I noticed that library was not being used to validate the phone number format.  This is the simplest change to make, but I recognize we may want to reference https://github.com/signalapp/libsignal-service-java instead.