### PR TITLE
The bug tracker has been disabled don't link to it

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,6 @@ Looking for protocol documentation? Check out the website!
 https://whispersystems.org/docs/
 
 
-Bug tracker
------------
-
-Have a bug? Please create an issue here on GitHub!
-
-https://github.com/WhisperSystems/Signal-Server/issues
-
-
 Mailing list
 ------------
 


### PR DESCRIPTION
(I was originally hear to file a bug asking for a status page for the signal server infra, but since the bug tracker is disabled, the least I can do is fix the readme :-))