### PR TITLE
continuous integration on travis & linting via PMD

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+language: java
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: java
 
+notifications:
+  email: false
+
 cache:
   directories:
   - $HOME/.m2
-
-
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,8 @@
 language: java
 
+cache:
+  directories:
+  - $HOME/.m2
+
+
+

--- a/pmd.xml
+++ b/pmd.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<ruleset name="Custom ruleset" xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
+
+    <description>
+        PMD configuration for the Signal server. Disables some buggy or overly verbose rules
+    </description>
+
+    <!-- don't lint generated code -->
+    <exclude-pattern>.*/org/whispersystems/textsecuregcm/.*Protos.java</exclude-pattern>
+
+    <rule ref="category/java/bestpractices.xml">
+        <exclude name="GuardLogStatement" /> <!-- following adds unnecessary verbosity -->
+        <exclude name="AccessorMethodGeneration" /> <!-- only really matters for Android -->
+        <exclude name="PreserveStackTrace" /> <!-- lots of these extant -->
+    </rule>
+
+    <!-- additional rulesets to enable over time -->
+    <!-- <ruleset>/category/java/errorprone.xml</ruleset> -->
+    <!-- <ruleset>/category/java/multithreading.xml</ruleset> -->
+    <!-- <ruleset>/category/java/performance.xml</ruleset> -->
+</ruleset>

--- a/pmd.xml
+++ b/pmd.xml
@@ -13,7 +13,11 @@
     <rule ref="category/java/bestpractices.xml">
         <exclude name="GuardLogStatement" /> <!-- following adds unnecessary verbosity -->
         <exclude name="AccessorMethodGeneration" /> <!-- only really matters for Android -->
-        <exclude name="PreserveStackTrace" /> <!-- lots of these extant -->
+        <exclude name="PositionLiteralsFirstInComparisons" /> <!-- hurts readability, low priority -->
+        <!-- lots of the following rules extant in the codebase -->
+        <exclude name="PreserveStackTrace" />
+        <exclude name="AccessorClassGeneration" />
+        <exclude name="UnusedPrivateField" />
     </rule>
 
     <!-- additional rulesets to enable over time -->

--- a/pom.xml
+++ b/pom.xml
@@ -265,6 +265,28 @@
                 </executions>
             </plugin>
 
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-pmd-plugin</artifactId>
+                <version>3.10.0</version>
+                <configuration>
+                    <rulesets>
+                        <ruleset>/category/java/bestpractices.xml</ruleset>
+                        <!-- additional rulesets to enable over time -->
+                        <!-- <ruleset>/category/java/errorprone.xml</ruleset> -->
+                        <!-- <ruleset>/category/java/multithreading.xml</ruleset> -->
+                        <!-- <ruleset>/category/java/performance.xml</ruleset> -->
+                    </rulesets>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -271,11 +271,7 @@
                 <version>3.10.0</version>
                 <configuration>
                     <rulesets>
-                        <ruleset>/category/java/bestpractices.xml</ruleset>
-                        <!-- additional rulesets to enable over time -->
-                        <!-- <ruleset>/category/java/errorprone.xml</ruleset> -->
-                        <!-- <ruleset>/category/java/multithreading.xml</ruleset> -->
-                        <!-- <ruleset>/category/java/performance.xml</ruleset> -->
+                        <ruleset>pmd.xml</ruleset>
                     </rulesets>
                 </configuration>
                 <executions>

--- a/src/main/java/org/whispersystems/dispatch/redis/PubSubConnection.java
+++ b/src/main/java/org/whispersystems/dispatch/redis/PubSubConnection.java
@@ -111,7 +111,7 @@ public class PubSubConnection {
     byte[]            channelName       = inputStream.readFully(channelNameHeader.getStringLength());
     inputStream.readLine();
 
-    IntReply subscriptionCount = new IntReply(inputStream.readLine());
+    IntReply subscriptionCount = new IntReply(inputStream.readLine()); // NOPMD
 
     return new String(channelName);
   }

--- a/src/main/java/org/whispersystems/textsecuregcm/WhisperServerConfiguration.java
+++ b/src/main/java/org/whispersystems/textsecuregcm/WhisperServerConfiguration.java
@@ -18,6 +18,7 @@ package org.whispersystems.textsecuregcm;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.whispersystems.textsecuregcm.configuration.ApnConfiguration;
+import org.whispersystems.textsecuregcm.configuration.AttachmentsConfiguration;
 import org.whispersystems.textsecuregcm.configuration.FederationConfiguration;
 import org.whispersystems.textsecuregcm.configuration.GcmConfiguration;
 import org.whispersystems.textsecuregcm.configuration.MaxDeviceConfiguration;
@@ -25,9 +26,7 @@ import org.whispersystems.textsecuregcm.configuration.MessageCacheConfiguration;
 import org.whispersystems.textsecuregcm.configuration.ProfilesConfiguration;
 import org.whispersystems.textsecuregcm.configuration.PushConfiguration;
 import org.whispersystems.textsecuregcm.configuration.RateLimitsConfiguration;
-import org.whispersystems.textsecuregcm.configuration.RedPhoneConfiguration;
 import org.whispersystems.textsecuregcm.configuration.RedisConfiguration;
-import org.whispersystems.textsecuregcm.configuration.AttachmentsConfiguration;
 import org.whispersystems.textsecuregcm.configuration.TestDeviceConfiguration;
 import org.whispersystems.textsecuregcm.configuration.TurnConfiguration;
 import org.whispersystems.textsecuregcm.configuration.TwilioConfiguration;

--- a/src/main/java/org/whispersystems/textsecuregcm/auth/AuthorizationToken.java
+++ b/src/main/java/org/whispersystems/textsecuregcm/auth/AuthorizationToken.java
@@ -2,18 +2,6 @@ package org.whispersystems.textsecuregcm.auth;
 
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.apache.commons.codec.DecoderException;
-import org.apache.commons.codec.binary.Hex;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.whispersystems.textsecuregcm.util.Util;
-
-import javax.crypto.Mac;
-import javax.crypto.spec.SecretKeySpec;
-import java.security.InvalidKeyException;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.util.concurrent.TimeUnit;
 
 public class AuthorizationToken {
 

--- a/src/main/java/org/whispersystems/textsecuregcm/configuration/MessageCacheConfiguration.java
+++ b/src/main/java/org/whispersystems/textsecuregcm/configuration/MessageCacheConfiguration.java
@@ -1,8 +1,6 @@
 package org.whispersystems.textsecuregcm.configuration;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.glassfish.jersey.server.JSONP;
-import org.hibernate.validator.constraints.NotEmpty;
 
 import javax.validation.Valid;
 import javax.validation.constraints.Max;

--- a/src/main/java/org/whispersystems/textsecuregcm/configuration/PushConfiguration.java
+++ b/src/main/java/org/whispersystems/textsecuregcm/configuration/PushConfiguration.java
@@ -1,7 +1,6 @@
 package org.whispersystems.textsecuregcm.configuration;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.hibernate.validator.constraints.NotEmpty;
 
 import javax.validation.constraints.Min;
 

--- a/src/main/java/org/whispersystems/textsecuregcm/configuration/RedisConfiguration.java
+++ b/src/main/java/org/whispersystems/textsecuregcm/configuration/RedisConfiguration.java
@@ -19,7 +19,6 @@ package org.whispersystems.textsecuregcm.configuration;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.hibernate.validator.constraints.NotEmpty;
-import org.hibernate.validator.constraints.URL;
 
 import javax.validation.constraints.NotNull;
 import java.util.List;

--- a/src/main/java/org/whispersystems/textsecuregcm/controllers/DeviceController.java
+++ b/src/main/java/org/whispersystems/textsecuregcm/controllers/DeviceController.java
@@ -50,7 +50,6 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.util.LinkedList;
 import java.util.List;

--- a/src/main/java/org/whispersystems/textsecuregcm/entities/ClientContact.java
+++ b/src/main/java/org/whispersystems/textsecuregcm/entities/ClientContact.java
@@ -101,6 +101,7 @@ public class ClientContact {
         (this.relay == null ? (that.relay == null) : this.relay.equals(that.relay));
   }
 
+  @Override
   public int hashCode() {
     return Arrays.hashCode(this.token);
   }

--- a/src/main/java/org/whispersystems/textsecuregcm/entities/IncomingMessage.java
+++ b/src/main/java/org/whispersystems/textsecuregcm/entities/IncomingMessage.java
@@ -17,7 +17,6 @@
 package org.whispersystems.textsecuregcm.entities;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.hibernate.validator.constraints.NotEmpty;
 
 public class IncomingMessage {
 

--- a/src/main/java/org/whispersystems/textsecuregcm/entities/OutgoingMessageEntityList.java
+++ b/src/main/java/org/whispersystems/textsecuregcm/entities/OutgoingMessageEntityList.java
@@ -1,7 +1,6 @@
 package org.whispersystems.textsecuregcm.entities;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.annotations.VisibleForTesting;
 
 import java.util.List;
 

--- a/src/main/java/org/whispersystems/textsecuregcm/entities/Profile.java
+++ b/src/main/java/org/whispersystems/textsecuregcm/entities/Profile.java
@@ -3,10 +3,6 @@ package org.whispersystems.textsecuregcm.entities;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.annotations.VisibleForTesting;
 
-import org.hibernate.validator.constraints.Length;
-
-import javax.validation.constraints.Max;
-
 public class Profile {
 
   @JsonProperty

--- a/src/main/java/org/whispersystems/textsecuregcm/entities/RelayMessage.java
+++ b/src/main/java/org/whispersystems/textsecuregcm/entities/RelayMessage.java
@@ -24,7 +24,6 @@ import org.hibernate.validator.constraints.NotEmpty;
 import org.whispersystems.textsecuregcm.util.ByteArrayAdapter;
 
 import javax.validation.constraints.NotNull;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 public class RelayMessage {
 

--- a/src/main/java/org/whispersystems/textsecuregcm/federation/FederatedClientManager.java
+++ b/src/main/java/org/whispersystems/textsecuregcm/federation/FederatedClientManager.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 
 import io.dropwizard.client.JerseyClientConfiguration;
 import io.dropwizard.setup.Environment;
@@ -32,7 +33,7 @@ public class FederatedClientManager {
 
   private final Logger logger = LoggerFactory.getLogger(FederatedClientManager.class);
 
-  private final HashMap<String, FederatedClient> clients = new HashMap<>();
+  private final Map<String, FederatedClient> clients = new HashMap<>();
 
   public FederatedClientManager(Environment environment,
                                 JerseyClientConfiguration clientConfig,

--- a/src/main/java/org/whispersystems/textsecuregcm/liquibase/AbstractLiquibaseCommand.java
+++ b/src/main/java/org/whispersystems/textsecuregcm/liquibase/AbstractLiquibaseCommand.java
@@ -43,7 +43,7 @@ public abstract class AbstractLiquibaseCommand<T extends Configuration> extends 
     final PooledDataSourceFactory dbConfig = strategy.getDataSourceFactory(configuration);
     dbConfig.asSingleConnectionPool();
 
-    try (final CloseableLiquibase liquibase = openLiquibase(dbConfig, namespace)) {
+    try (final CloseableLiquibase liquibase = openLiquibase(dbConfig)) {
       run(namespace, liquibase);
     } catch (ValidationFailedException e) {
       e.printDescriptiveError(System.err);
@@ -51,7 +51,7 @@ public abstract class AbstractLiquibaseCommand<T extends Configuration> extends 
     }
   }
 
-  private CloseableLiquibase openLiquibase(final PooledDataSourceFactory dataSourceFactory, final Namespace namespace)
+  private CloseableLiquibase openLiquibase(final PooledDataSourceFactory dataSourceFactory)
       throws ClassNotFoundException, SQLException, LiquibaseException
   {
     final ManagedDataSource dataSource = dataSourceFactory.build(new MetricRegistry(), "liquibase");

--- a/src/main/java/org/whispersystems/textsecuregcm/liquibase/NameableMigrationsBundle.java
+++ b/src/main/java/org/whispersystems/textsecuregcm/liquibase/NameableMigrationsBundle.java
@@ -17,11 +17,13 @@ public abstract class NameableMigrationsBundle<T extends Configuration> implemen
     this.migrations = migrations;
   }
 
+  @Override
   public final void initialize(Bootstrap<?> bootstrap) {
     Class klass = Generics.getTypeParameter(this.getClass(), Configuration.class);
     bootstrap.addCommand(new NameableDbCommand(name, migrations, this, klass));
   }
 
+  @Override
   public final void run(Environment environment) {
   }
 }

--- a/src/main/java/org/whispersystems/textsecuregcm/metrics/LoggingNetworkAppenderFactory.java
+++ b/src/main/java/org/whispersystems/textsecuregcm/metrics/LoggingNetworkAppenderFactory.java
@@ -74,10 +74,12 @@ public class LoggingNetworkAppenderFactory extends AbstractAppenderFactory<ILogg
     this.port = port;
   }
 
+  @Override
   public TimeZone getTimeZone() {
     return timeZone;
   }
 
+  @Override
   public void setTimeZone(final TimeZone timeZone) {
     this.timeZone = timeZone;
   }

--- a/src/main/java/org/whispersystems/textsecuregcm/metrics/NetworkGauge.java
+++ b/src/main/java/org/whispersystems/textsecuregcm/metrics/NetworkGauge.java
@@ -14,8 +14,8 @@ public abstract class NetworkGauge implements Gauge<Double> {
   protected Pair<Long, Long> getSentReceived() throws IOException {
     File           proc          = new File("/proc/net/dev");
     BufferedReader reader        = new BufferedReader(new FileReader(proc));
-    String         header        = reader.readLine();
-    String         header2       = reader.readLine();
+    String         header        = reader.readLine(); // NOPMD
+    String         header2       = reader.readLine(); // NOPMD
 
     long           bytesSent     = 0;
     long           bytesReceived = 0;

--- a/src/main/java/org/whispersystems/textsecuregcm/push/APNSender.java
+++ b/src/main/java/org/whispersystems/textsecuregcm/push/APNSender.java
@@ -28,7 +28,6 @@ import org.whispersystems.textsecuregcm.push.RetryingApnsClient.ApnResult;
 import org.whispersystems.textsecuregcm.storage.Account;
 import org.whispersystems.textsecuregcm.storage.AccountsManager;
 import org.whispersystems.textsecuregcm.storage.Device;
-import org.whispersystems.textsecuregcm.websocket.WebsocketAddress;
 
 import javax.annotation.Nullable;
 import java.io.IOException;

--- a/src/main/java/org/whispersystems/textsecuregcm/push/ApnFallbackManager.java
+++ b/src/main/java/org/whispersystems/textsecuregcm/push/ApnFallbackManager.java
@@ -19,6 +19,7 @@ import org.whispersystems.textsecuregcm.websocket.WebsocketAddress;
 
 import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.TimeUnit;
 
@@ -188,7 +189,7 @@ public class ApnFallbackManager implements Managed, Runnable, DispatchChannel {
   @VisibleForTesting
   public static class ApnFallbackTaskQueue {
 
-    private final LinkedHashMap<WebsocketAddress, ApnFallbackTask> tasks = new LinkedHashMap<>();
+    private final Map<WebsocketAddress, ApnFallbackTask> tasks = new LinkedHashMap<>();
 
     public Entry<WebsocketAddress, ApnFallbackTask> get() {
       while (true) {

--- a/src/main/java/org/whispersystems/textsecuregcm/redis/ReplicatedJedisPool.java
+++ b/src/main/java/org/whispersystems/textsecuregcm/redis/ReplicatedJedisPool.java
@@ -19,7 +19,7 @@ public class ReplicatedJedisPool {
   private final JedisPool[] replicas;
 
   public ReplicatedJedisPool(JedisPool master, List<JedisPool> replicas) {
-    if (replicas.size() < 1) throw new IllegalArgumentException("There must be at least one replica");
+    if (replicas.isEmpty()) throw new IllegalArgumentException("There must be at least one replica");
 
     this.master   = master;
     this.replicas = new JedisPool[replicas.size()];

--- a/src/main/java/org/whispersystems/textsecuregcm/s3/PolicySigner.java
+++ b/src/main/java/org/whispersystems/textsecuregcm/s3/PolicySigner.java
@@ -1,7 +1,6 @@
 package org.whispersystems.textsecuregcm.s3;
 
 import com.amazonaws.util.Base16Lower;
-import com.google.common.annotations.VisibleForTesting;
 
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;

--- a/src/main/java/org/whispersystems/textsecuregcm/sms/TwilioSmsSender.java
+++ b/src/main/java/org/whispersystems/textsecuregcm/sms/TwilioSmsSender.java
@@ -53,7 +53,7 @@ public class TwilioSmsSender {
 
   private final String            accountId;
   private final String            accountToken;
-  private final ArrayList<String> numbers;
+  private final List<String>      numbers;
   private final String            messagingServicesId;
   private final String            localDomain;
   private final Random            random;
@@ -115,7 +115,7 @@ public class TwilioSmsSender {
     voxMeter.mark();
   }
 
-  private String getRandom(Random random, ArrayList<String> elements) {
+  private String getRandom(Random random, List<String> elements) {
     return elements.get(random.nextInt(elements.size()));
   }
 

--- a/src/main/java/org/whispersystems/textsecuregcm/storage/Accounts.java
+++ b/src/main/java/org/whispersystems/textsecuregcm/storage/Accounts.java
@@ -25,7 +25,6 @@ import org.skife.jdbi.v2.sqlobject.Bind;
 import org.skife.jdbi.v2.sqlobject.Binder;
 import org.skife.jdbi.v2.sqlobject.BinderFactory;
 import org.skife.jdbi.v2.sqlobject.BindingAnnotation;
-import org.skife.jdbi.v2.sqlobject.GetGeneratedKeys;
 import org.skife.jdbi.v2.sqlobject.SqlQuery;
 import org.skife.jdbi.v2.sqlobject.SqlUpdate;
 import org.skife.jdbi.v2.sqlobject.Transaction;

--- a/src/main/java/org/whispersystems/textsecuregcm/util/Pair.java
+++ b/src/main/java/org/whispersystems/textsecuregcm/util/Pair.java
@@ -35,12 +35,14 @@ public class Pair<T1, T2> {
     return v2;
   }
 
+  @Override
   public boolean equals(Object o) {
     return o instanceof Pair &&
         equal(((Pair) o).first(), first()) &&
         equal(((Pair) o).second(), second());
   }
 
+  @Override
   public int hashCode() {
     return first().hashCode() ^ second().hashCode();
   }

--- a/src/main/java/org/whispersystems/textsecuregcm/util/VerificationCode.java
+++ b/src/main/java/org/whispersystems/textsecuregcm/util/VerificationCode.java
@@ -17,10 +17,7 @@
 package org.whispersystems.textsecuregcm.util;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.annotations.VisibleForTesting;
 
 public class VerificationCode {

--- a/src/main/java/org/whispersystems/textsecuregcm/util/VerificationCode.java
+++ b/src/main/java/org/whispersystems/textsecuregcm/util/VerificationCode.java
@@ -63,10 +63,12 @@ public class VerificationCode {
     return delimited;
   }
 
+  @Override
   @VisibleForTesting public boolean equals(Object o) {
     return o instanceof VerificationCode && verificationCode.equals(((VerificationCode) o).verificationCode);
   }
 
+  @Override
   public int hashCode() {
     return Integer.parseInt(verificationCode);
   }

--- a/src/main/java/org/whispersystems/textsecuregcm/websocket/AuthenticatedConnectListener.java
+++ b/src/main/java/org/whispersystems/textsecuregcm/websocket/AuthenticatedConnectListener.java
@@ -15,7 +15,6 @@ import org.whispersystems.textsecuregcm.storage.MessagesManager;
 import org.whispersystems.textsecuregcm.storage.PubSubManager;
 import org.whispersystems.textsecuregcm.storage.PubSubProtos.PubSubMessage;
 import org.whispersystems.textsecuregcm.util.Constants;
-import org.whispersystems.textsecuregcm.util.Util;
 import org.whispersystems.websocket.session.WebSocketSessionContext;
 import org.whispersystems.websocket.setup.WebSocketConnectListener;
 

--- a/src/main/java/org/whispersystems/textsecuregcm/websocket/DeadLetterHandler.java
+++ b/src/main/java/org/whispersystems/textsecuregcm/websocket/DeadLetterHandler.java
@@ -32,6 +32,8 @@ public class DeadLetterHandler implements DispatchChannel {
             Envelope message = Envelope.parseFrom(pubSubMessage.getContent());
             messagesManager.insert(address.getNumber(), address.getDeviceId(), message);
             break;
+          default:
+            break;
         }
       } catch (InvalidProtocolBufferException e) {
         logger.warn("Bad pubsub message", e);

--- a/src/main/java/org/whispersystems/textsecuregcm/websocket/ProvisioningAddress.java
+++ b/src/main/java/org/whispersystems/textsecuregcm/websocket/ProvisioningAddress.java
@@ -2,7 +2,6 @@ package org.whispersystems.textsecuregcm.websocket;
 
 import org.whispersystems.textsecuregcm.util.Base64;
 
-import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 
 public class ProvisioningAddress extends WebsocketAddress {

--- a/src/main/java/org/whispersystems/textsecuregcm/websocket/WebSocketAccountAuthenticator.java
+++ b/src/main/java/org/whispersystems/textsecuregcm/websocket/WebSocketAccountAuthenticator.java
@@ -28,8 +28,8 @@ public class WebSocketAccountAuthenticator implements WebSocketAuthenticator<Acc
       List<String>              usernames  = parameters.get("login");
       List<String>              passwords  = parameters.get("password");
 
-      if (usernames == null || usernames.size() == 0 ||
-          passwords == null || passwords.size() == 0)
+      if (usernames == null || usernames.isEmpty() ||
+          passwords == null || passwords.isEmpty())
       {
         return Optional.absent();
       }

--- a/src/main/java/org/whispersystems/textsecuregcm/websocket/WebSocketAccountAuthenticator.java
+++ b/src/main/java/org/whispersystems/textsecuregcm/websocket/WebSocketAccountAuthenticator.java
@@ -4,7 +4,6 @@ import com.google.common.base.Optional;
 import org.eclipse.jetty.websocket.api.UpgradeRequest;
 import org.whispersystems.textsecuregcm.auth.AccountAuthenticator;
 import org.whispersystems.textsecuregcm.storage.Account;
-import org.whispersystems.textsecuregcm.storage.Device;
 import org.whispersystems.websocket.auth.AuthenticationException;
 import org.whispersystems.websocket.auth.WebSocketAuthenticator;
 

--- a/src/main/java/org/whispersystems/textsecuregcm/websocket/WebSocketConnection.java
+++ b/src/main/java/org/whispersystems/textsecuregcm/websocket/WebSocketConnection.java
@@ -102,6 +102,7 @@ public class WebSocketConnection implements DispatchChannel {
     client.close(1000, "OK");
   }
 
+  @Override
   public void onDispatchSubscribed(String channel) {
     processStoredMessages();
   }

--- a/src/main/java/org/whispersystems/textsecuregcm/websocket/WebSocketConnectionInfo.java
+++ b/src/main/java/org/whispersystems/textsecuregcm/websocket/WebSocketConnectionInfo.java
@@ -25,6 +25,7 @@ public class WebSocketConnectionInfo implements PubSubAddress {
     }
   }
 
+  @Override
   public String serialize() {
     return address.serialize() + ":c";
   }

--- a/src/main/java/org/whispersystems/textsecuregcm/websocket/WebsocketAddress.java
+++ b/src/main/java/org/whispersystems/textsecuregcm/websocket/WebsocketAddress.java
@@ -35,10 +35,12 @@ public class WebsocketAddress implements PubSubAddress {
     return deviceId;
   }
 
+  @Override
   public String serialize() {
     return number + ":" + deviceId;
   }
 
+  @Override
   public String toString() {
     return serialize();
   }

--- a/src/main/java/org/whispersystems/textsecuregcm/workers/DeleteUserCommand.java
+++ b/src/main/java/org/whispersystems/textsecuregcm/workers/DeleteUserCommand.java
@@ -28,7 +28,6 @@ import io.dropwizard.jdbi.ImmutableSetContainerFactory;
 import io.dropwizard.jdbi.OptionalContainerFactory;
 import io.dropwizard.jdbi.args.OptionalArgumentFactory;
 import io.dropwizard.setup.Environment;
-import redis.clients.jedis.JedisPool;
 
 public class DeleteUserCommand extends EnvironmentCommand<WhisperServerConfiguration> {
 

--- a/src/main/java/org/whispersystems/textsecuregcm/workers/DirectoryCommand.java
+++ b/src/main/java/org/whispersystems/textsecuregcm/workers/DirectoryCommand.java
@@ -22,7 +22,6 @@ import org.skife.jdbi.v2.DBI;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.whispersystems.textsecuregcm.WhisperServerConfiguration;
-import org.whispersystems.textsecuregcm.federation.FederatedClientManager;
 import org.whispersystems.textsecuregcm.providers.RedisClientFactory;
 import org.whispersystems.textsecuregcm.redis.ReplicatedJedisPool;
 import org.whispersystems.textsecuregcm.storage.Accounts;
@@ -30,16 +29,13 @@ import org.whispersystems.textsecuregcm.storage.AccountsManager;
 import org.whispersystems.textsecuregcm.storage.DirectoryManager;
 
 import io.dropwizard.Application;
-import io.dropwizard.cli.ConfiguredCommand;
 import io.dropwizard.cli.EnvironmentCommand;
 import io.dropwizard.db.DataSourceFactory;
 import io.dropwizard.jdbi.ImmutableListContainerFactory;
 import io.dropwizard.jdbi.ImmutableSetContainerFactory;
 import io.dropwizard.jdbi.OptionalContainerFactory;
 import io.dropwizard.jdbi.args.OptionalArgumentFactory;
-import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
-import redis.clients.jedis.JedisPool;
 
 public class DirectoryCommand extends EnvironmentCommand<WhisperServerConfiguration> {
 

--- a/src/main/java/org/whispersystems/textsecuregcm/workers/DirectoryUpdater.java
+++ b/src/main/java/org/whispersystems/textsecuregcm/workers/DirectoryUpdater.java
@@ -16,24 +16,16 @@
  */
 package org.whispersystems.textsecuregcm.workers;
 
-import com.google.common.base.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.whispersystems.textsecuregcm.entities.ClientContact;
-import org.whispersystems.textsecuregcm.federation.FederatedClient;
-import org.whispersystems.textsecuregcm.federation.FederatedClientManager;
 import org.whispersystems.textsecuregcm.storage.Account;
 import org.whispersystems.textsecuregcm.storage.AccountsManager;
 import org.whispersystems.textsecuregcm.storage.DirectoryManager;
 import org.whispersystems.textsecuregcm.storage.DirectoryManager.BatchOperationHandle;
 import org.whispersystems.textsecuregcm.util.Util;
 
-import java.io.IOException;
-import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
-
-import static org.whispersystems.textsecuregcm.storage.DirectoryManager.PendingClientContact;
 
 public class DirectoryUpdater {
 


### PR DESCRIPTION
When I was browsing the repo the other day I noticed that there wasn't static linting set up as part of the build. I'm a big fan of PMD to help reduce bikeshedding on PRs and keep things neat and tidy so I set it up along with fixes for some of the low-hanging fruit. If this is helpful I'm happy to set up [error-prone](https://github.com/google/error-prone) next - it seems to do a better job catching logic and encoding errors than PMD. 

There are 16 outstanding violations as of posting this PR, I've attached a PDF w/ them. Didn't want to wade in any further without putting this on your radar. 

The Travis build against my fork lives here: https://travis-ci.org/gnmerritt/Signal-Server

[Signal PMD outstanding.pdf](https://github.com/signalapp/Signal-Server/files/2177537/Signal.PMD.outstanding.pdf)
