### PR TITLE
add unit tests for SmsSender

### DIFF
--- a/service/src/main/java/org/whispersystems/textsecuregcm/sms/SmsSender.java
+++ b/service/src/main/java/org/whispersystems/textsecuregcm/sms/SmsSender.java
@@ -39,7 +39,7 @@ public class SmsSender {
   public void deliverSmsVerification(String destination, Optional<String> clientType, String verificationCode) {
     // Fix up mexico numbers to 'mobile' format just for SMS delivery.
     if (destination.startsWith("+52") && !destination.startsWith("+521")) {
-      destination = "+521" + destination.substring(3);
+      destination = "+521" + destination.substring("+52".length());
     }
 
     twilioSender.deliverSmsVerification(destination, clientType, verificationCode);

--- a/service/src/test/java/org/whispersystems/textsecuregcm/tests/sms/SmsSenderTest.java
+++ b/service/src/test/java/org/whispersystems/textsecuregcm/tests/sms/SmsSenderTest.java
@@ -1,0 +1,42 @@
+package org.whispersystems.textsecuregcm.tests.sms;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+
+import java.util.Optional;
+
+import org.junit.Test;
+import org.whispersystems.textsecuregcm.sms.SmsSender;
+import org.whispersystems.textsecuregcm.sms.TwilioSmsSender;
+
+public class SmsSenderTest {
+
+  private static final String NON_MEXICO_NUMBER        = "+12345678901";
+  private static final String MEXICO_NON_MOBILE_NUMBER = "+52234567890";
+  private static final String MEXICO_MOBILE_NUMBER     = "+52123456789";
+
+  private final TwilioSmsSender twilioSmsSender = mock(TwilioSmsSender.class);
+  private final SmsSender       smsSender       = new SmsSender(twilioSmsSender);
+
+  @Test
+  public void testDeliverSmsVerificationNonMexico() {
+    smsSender.deliverSmsVerification(NON_MEXICO_NUMBER, Optional.empty(), "");
+    verify(twilioSmsSender, times(1))
+        .deliverSmsVerification(NON_MEXICO_NUMBER, Optional.empty(), "");
+  }
+
+  @Test
+  public void testDeliverSmsVerificationMexicoNonMobile() {
+    smsSender.deliverSmsVerification(MEXICO_NON_MOBILE_NUMBER, Optional.empty(), "");
+    verify(twilioSmsSender, times(1))
+        .deliverSmsVerification("+521" + MEXICO_NON_MOBILE_NUMBER.substring("+52".length()), Optional.empty(), "");
+  }
+
+  @Test
+  public void testDeliverSmsVerificationMexicoMobile() {
+    smsSender.deliverSmsVerification(MEXICO_MOBILE_NUMBER, Optional.empty(), "");
+    verify(twilioSmsSender, times(1))
+        .deliverSmsVerification(MEXICO_MOBILE_NUMBER, Optional.empty(), "");
+  }
+}


### PR DESCRIPTION
Was just looking around the codebase and noticed a special condition that I thought could use a unit test. I think the slight change I made to the substring indexing makes the code a little more clear too.