### PR TITLE
Add FUNDING.yml to display sponsor button in GitHub

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,4 @@
+# Copyright 2021 Signal Messenger, LLC
+# SPDX-License-Identifier: AGPL-3.0-only
+
+custom: https://signal.org/donate/


### PR DESCRIPTION
Displays the Sponsor button on top of the GitHub interface. This file is similar to the [FUNDING.yml](https://github.com/signalapp/Signal-Desktop/blob/development/.github/FUNDING.yml) file on the Signal-Desktop repository.