### PR TITLE
Fix declared package name.

### DIFF
--- a/service/src/test/java/org/whispersystems/textsecuregcm/tests/sms/TwilioSmsSenderTest.java
+++ b/service/src/test/java/org/whispersystems/textsecuregcm/tests/sms/TwilioSmsSenderTest.java
@@ -1,4 +1,4 @@
-package org.whispersystems.sms;
+package org.whispersystems.textsecuregcm.tests.sms;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import org.junit.Rule;


### PR DESCRIPTION
The Java package for TwilioSmsSenderTest did not match the directory
holding the .java code.