### PR TITLE
Optimize logging

### DIFF
--- a/service/src/main/java/org/whispersystems/textsecuregcm/controllers/AccountController.java
+++ b/service/src/main/java/org/whispersystems/textsecuregcm/controllers/AccountController.java
@@ -570,7 +570,7 @@ public class AccountController {
     try {
       rateLimiters.getSmsVoicePrefixLimiter().validate(Util.getNumberPrefix(number));
     } catch (RateLimitExceededException e) {
-      logger.info("Prefix rate limit exceeded:{}, {}, ({})", transport, number, forwardedFor);
+      logger.info("Prefix rate limit exceeded: {}, {}, ({})", transport, number, forwardedFor);
       rateLimitedPrefixMeter.mark();
       return new CaptchaRequirement(true, true);
     }

--- a/service/src/main/java/org/whispersystems/textsecuregcm/controllers/AccountController.java
+++ b/service/src/main/java/org/whispersystems/textsecuregcm/controllers/AccountController.java
@@ -192,7 +192,7 @@ public class AccountController {
       throws RateLimitExceededException
   {
     if (!Util.isValidNumber(number)) {
-      logger.info("Invalid number: " + number);
+      logger.info("Invalid number: {}", number);
       throw new WebApplicationException(Response.status(400).build());
     }
 
@@ -206,7 +206,7 @@ public class AccountController {
 
     if (requirement.isCaptchaRequired()) {
       if (requirement.isAutoBlock() && shouldAutoBlock(requester)) {
-        logger.info("Auto-block: " + requester);
+        logger.info("Auto-block: {}", requester);
         abusiveHostRules.setBlockedHost(requester, "Auto-Block");
       }
 
@@ -545,14 +545,14 @@ public class AccountController {
 
     for (AbusiveHostRule abuseRule : abuseRules) {
       if (abuseRule.isBlocked()) {
-        logger.info("Blocked host: " + transport + ", " + number + ", " + requester + " (" + forwardedFor + ")");
+        logger.info("Blocked host: {}, {}, {}, ({})", transport, number, requester, forwardedFor);
         blockedHostMeter.mark();
         return new CaptchaRequirement(true, false);
       }
 
       if (!abuseRule.getRegions().isEmpty()) {
         if (abuseRule.getRegions().stream().noneMatch(number::startsWith)) {
-          logger.info("Restricted host: " + transport + ", " + number + ", " + requester + " (" + forwardedFor + ")");
+          logger.info("Restricted host: {}, {}, {}, ({})", transport, number, requester, forwardedFor);
           filteredHostMeter.mark();
           return new CaptchaRequirement(true, false);
         }
@@ -562,7 +562,7 @@ public class AccountController {
     try {
       rateLimiters.getSmsVoiceIpLimiter().validate(requester);
     } catch (RateLimitExceededException e) {
-      logger.info("Rate limited exceeded: " + transport + ", " + number + ", " + requester + " (" + forwardedFor + ")");
+      logger.info("Rate limited exceeded: {}, {}, {}, ({})", transport, number, requester, forwardedFor);
       rateLimitedHostMeter.mark();
       return new CaptchaRequirement(true, true);
     }
@@ -570,7 +570,7 @@ public class AccountController {
     try {
       rateLimiters.getSmsVoicePrefixLimiter().validate(Util.getNumberPrefix(number));
     } catch (RateLimitExceededException e) {
-      logger.info("Prefix rate limit exceeded: " + transport + ", " + number + ", (" + forwardedFor + ")");
+      logger.info("Prefix rate limit exceeded:{}, {}, ({})", transport, number, forwardedFor);
       rateLimitedPrefixMeter.mark();
       return new CaptchaRequirement(true, true);
     }

--- a/service/src/main/java/org/whispersystems/textsecuregcm/push/APNSender.java
+++ b/service/src/main/java/org/whispersystems/textsecuregcm/push/APNSender.java
@@ -135,7 +135,7 @@ public class APNSender implements Managed {
     Optional<Account> account = accountsManager.get(number);
 
     if (!account.isPresent()) {
-      logger.info("No account found: " + number);
+      logger.info("No account found: {}", number);
       unregisteredEventStale.mark();
       return;
     }
@@ -143,7 +143,7 @@ public class APNSender implements Managed {
     Optional<Device> device = account.get().getDevice(deviceId);
 
     if (!device.isPresent()) {
-      logger.info("No device found: " + number);
+      logger.info("No device found: {}", number);
       unregisteredEventStale.mark();
       return;
     }
@@ -166,7 +166,7 @@ public class APNSender implements Managed {
 
     if (tokenTimestamp != 0 && System.currentTimeMillis() < tokenTimestamp + TimeUnit.SECONDS.toMillis(10))
     {
-      logger.info("APN Unregister push timestamp is more recent: " + tokenTimestamp + ", " + number);
+      logger.info("APN Unregister push timestamp is more recent: {},{}", tokenTimestamp, number);
       unregisteredEventStale.mark();
       return;
     }

--- a/service/src/main/java/org/whispersystems/textsecuregcm/push/APNSender.java
+++ b/service/src/main/java/org/whispersystems/textsecuregcm/push/APNSender.java
@@ -166,7 +166,7 @@ public class APNSender implements Managed {
 
     if (tokenTimestamp != 0 && System.currentTimeMillis() < tokenTimestamp + TimeUnit.SECONDS.toMillis(10))
     {
-      logger.info("APN Unregister push timestamp is more recent: {},{}", tokenTimestamp, number);
+      logger.info("APN Unregister push timestamp is more recent: {}, {}", tokenTimestamp, number);
       unregisteredEventStale.mark();
       return;
     }

--- a/service/src/main/java/org/whispersystems/textsecuregcm/push/GCMSender.java
+++ b/service/src/main/java/org/whispersystems/textsecuregcm/push/GCMSender.java
@@ -174,6 +174,6 @@ public class GCMSender implements Managed {
     Meter meter = outboundMeters.get(key);
 
     if (meter != null) meter.mark();
-    else               logger.warn("Unknown outbound key: " + key);
+    else logger.warn("Unknown outbound key: {}", key);
   }
 }

--- a/service/src/main/java/org/whispersystems/textsecuregcm/sms/TwilioSmsSender.java
+++ b/service/src/main/java/org/whispersystems/textsecuregcm/sms/TwilioSmsSender.java
@@ -164,7 +164,7 @@ public class TwilioSmsSender {
       priceMeter.mark((long)(response.successResponse.price * 1000));
       return true;
     } else if (response != null && response.isFailure()) {
-      logger.info("Twilio request failed: " + response.failureResponse.status + ", " + response.failureResponse.message);
+      logger.info("Twilio request failed: {}, {}", response.failureResponse.status, response.failureResponse.message);
       return false;
     } else if (throwable != null) {
       logger.info("Twilio request failed", throwable);

--- a/service/src/main/java/org/whispersystems/textsecuregcm/websocket/DeadLetterHandler.java
+++ b/service/src/main/java/org/whispersystems/textsecuregcm/websocket/DeadLetterHandler.java
@@ -21,7 +21,7 @@ public class DeadLetterHandler implements DispatchChannel {
   @Override
   public void onDispatchMessage(String channel, byte[] data) {
     try {
-      logger.info("Handling dead letter to: " + channel);
+      logger.info("Handling dead letter to: {}", channel);
 
       WebsocketAddress address       = new WebsocketAddress(channel);
       PubSubMessage    pubSubMessage = PubSubMessage.parseFrom(data);
@@ -41,11 +41,11 @@ public class DeadLetterHandler implements DispatchChannel {
 
   @Override
   public void onDispatchSubscribed(String channel) {
-    logger.warn("DeadLetterHandler subscription notice! " + channel);
+    logger.warn("DeadLetterHandler subscription notice! {} ", channel);
   }
 
   @Override
   public void onDispatchUnsubscribed(String channel) {
-    logger.warn("DeadLetterHandler unsubscribe notice! " + channel);
+    logger.warn("DeadLetterHandler unsubscribe notice! {}", channel);
   }
 }

--- a/service/src/main/java/org/whispersystems/textsecuregcm/websocket/DeadLetterHandler.java
+++ b/service/src/main/java/org/whispersystems/textsecuregcm/websocket/DeadLetterHandler.java
@@ -41,7 +41,7 @@ public class DeadLetterHandler implements DispatchChannel {
 
   @Override
   public void onDispatchSubscribed(String channel) {
-    logger.warn("DeadLetterHandler subscription notice! {} ", channel);
+    logger.warn("DeadLetterHandler subscription notice! {}", channel);
   }
 
   @Override


### PR DESCRIPTION
passing concatenated strings into a logging method can lead to performance hit because, the concatenation will be performed every time the method is called, whether or not the log level is low enough to show the message