### PR TITLE
Stop background threads when the app is stopped.

### DIFF
--- a/service/pom.xml
+++ b/service/pom.xml
@@ -466,6 +466,12 @@
       <version>1.1.1</version>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 

--- a/service/src/main/java/org/whispersystems/textsecuregcm/util/Util.java
+++ b/service/src/main/java/org/whispersystems/textsecuregcm/util/Util.java
@@ -5,6 +5,7 @@
 package org.whispersystems.textsecuregcm.util;
 
 import com.google.i18n.phonenumbers.PhoneNumberUtil;
+
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.security.MessageDigest;
@@ -146,10 +147,23 @@ public class Util {
     return Util.toIntExact(System.currentTimeMillis() / 1000 / 60 / 60 / 24);
   }
 
+  /**
+   * @deprecated Favor {@link #sleepQuietly(long)} which restores the interrupt status.
+   */
+  @Deprecated
   public static void sleep(long i) {
     try {
       Thread.sleep(i);
     } catch (InterruptedException ie) {}
+  }
+
+  public static void sleepQuietly(long ms) {
+      try {
+        Thread.sleep(ms);
+      } catch (InterruptedException ie) {
+        // see https://pskb-prod.herokuapp.com/java-and-j2ee/don-t-swallow-interruptedexception-call-thread-currentthread-interrupt-instead
+        Thread.currentThread().interrupt();
+      }
   }
 
   public static void wait(Object object) {


### PR DESCRIPTION
```
Stop background threads when the app is stopped.

When the app is stopped, attempt to stop background threads for
- currency conversion and
- remote configs

Deprecated Util::sleep and added Util::sleepQuietly as replacement.
```