### PR TITLE
Use Map.of() for statically defined map

### DIFF
--- a/service/src/main/java/org/whispersystems/textsecuregcm/controllers/AttachmentControllerV3.java
+++ b/service/src/main/java/org/whispersystems/textsecuregcm/controllers/AttachmentControllerV3.java
@@ -74,11 +74,10 @@ public class AttachmentControllerV3 extends AttachmentControllerBase {
   }
 
   private static Map<String, String> getHeaderMap(@Nonnull CanonicalRequest canonicalRequest) {
-    Map<String, String> result = new HashMap<>(3);
-    result.put("host", canonicalRequest.getDomain());
-    result.put("x-goog-content-length-range", "1," + canonicalRequest.getMaxSizeInBytes());
-    result.put("x-goog-resumable", "start");
-    return result;
+    return Map.of(
+      "host", canonicalRequest.getDomain(),
+      "x-goog-content-length-range", "1," + canonicalRequest.getMaxSizeInBytes(),
+      "x-goog-resumable", "start");
   }
 
   private String generateAttachmentKey() {


### PR DESCRIPTION
Hello, 

I just randomly appeared to look at the code and found weird the size given to the HashMap constructor.
The JDK11 comes with Map.of() that should help at making these maps more efficient, so, perhaps it's worth updating?

