### PR TITLE
Migrate AppConfig to SDK v2 to detect and use web identify token

### DIFF
--- a/service/pom.xml
+++ b/service/pom.xml
@@ -257,6 +257,10 @@
 
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
+      <artifactId>sts</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
       <artifactId>s3</artifactId>
     </dependency>
     <dependency>
@@ -268,16 +272,16 @@
       <artifactId>dynamodb</artifactId>
     </dependency>
     <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>appconfig</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-core</artifactId>
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-s3</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.amazonaws</groupId>
-      <artifactId>aws-java-sdk-appconfig</artifactId>
     </dependency>
 
     <dependency>

--- a/service/src/test/java/org/whispersystems/textsecuregcm/storage/DynamicConfigurationManagerTest.java
+++ b/service/src/test/java/org/whispersystems/textsecuregcm/storage/DynamicConfigurationManagerTest.java
@@ -1,42 +1,40 @@
 package org.whispersystems.textsecuregcm.storage;
 
-import com.amazonaws.services.appconfig.AmazonAppConfig;
-import com.amazonaws.services.appconfig.model.GetConfigurationRequest;
-import com.amazonaws.services.appconfig.model.GetConfigurationResult;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
-
-import java.nio.ByteBuffer;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.appconfig.AppConfigClient;
+import software.amazon.awssdk.services.appconfig.model.GetConfigurationRequest;
+import software.amazon.awssdk.services.appconfig.model.GetConfigurationResponse;
 
 public class DynamicConfigurationManagerTest {
 
   private DynamicConfigurationManager dynamicConfigurationManager;
-  private AmazonAppConfig             appConfig;
+  private AppConfigClient             appConfig;
 
   @Before
   public void setup() {
-    this.appConfig                   = mock(AmazonAppConfig.class);
+    this.appConfig                   = mock(AppConfigClient.class);
     this.dynamicConfigurationManager = new DynamicConfigurationManager(appConfig, "foo", "bar", "baz", "poof");
   }
 
   @Test
   public void testGetConfig() {
     ArgumentCaptor<GetConfigurationRequest> captor = ArgumentCaptor.forClass(GetConfigurationRequest.class);
-    when(appConfig.getConfiguration(captor.capture())).thenReturn(new GetConfigurationResult().withContent(ByteBuffer.wrap("test: true".getBytes()))
-                                                                                              .withConfigurationVersion("1"));
+    when(appConfig.getConfiguration(captor.capture())).thenReturn(
+        GetConfigurationResponse.builder().content(SdkBytes.fromByteArray("test: true".getBytes())).configurationVersion("1").build());
 
     dynamicConfigurationManager.start();
 
-    assertThat(captor.getValue().getApplication()).isEqualTo("foo");
-    assertThat(captor.getValue().getEnvironment()).isEqualTo("bar");
-    assertThat(captor.getValue().getConfiguration()).isEqualTo("baz");
-    assertThat(captor.getValue().getClientId()).isEqualTo("poof");
+    assertThat(captor.getValue().application()).isEqualTo("foo");
+    assertThat(captor.getValue().environment()).isEqualTo("bar");
+    assertThat(captor.getValue().configuration()).isEqualTo("baz");
+    assertThat(captor.getValue().clientId()).isEqualTo("poof");
 
     assertThat(dynamicConfigurationManager.getConfiguration()).isNotNull();
   }


### PR DESCRIPTION
Hi,

When setting up server in RBAC-enabled EKS cluster, the original AppConfig client cannot use web identity token for authentication.  This commit make that possible, please consider merge the code.

Thanks,