### PR TITLE
Prevent unit tests from failing for machines with a non-US default Locale

### DIFF
--- a/websocket-resources/src/test/java/org/whispersystems/websocket/logging/WebSocketRequestLogTest.java
+++ b/websocket-resources/src/test/java/org/whispersystems/websocket/logging/WebSocketRequestLogTest.java
@@ -22,6 +22,7 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -36,10 +37,10 @@ public class WebSocketRequestLogTest {
     WebsocketRequestLoggerFactory requestLoggerFactory = new WebsocketRequestLoggerFactory();
     requestLoggerFactory.appenders = List.of(new ListAppenderFactory<>(listAppender));
 
+    Locale.setDefault(Locale.US);
     WebsocketRequestLog requestLog = requestLoggerFactory.build("test-logger");
     ContainerRequest    request    = new ContainerRequest (null, URI.create("/v1/test"), "GET", new WebSocketSecurityContext(new ContextPrincipal(sessionContext)), new MapPropertiesDelegate(new HashMap<>()), null);
     ContainerResponse   response   = new ContainerResponse(request, Response.ok("My response body").build());
-
     requestLog.log("123.456.789.123", request, response);
 
     listAppender.waitForListSize(1);
@@ -57,6 +58,7 @@ public class WebSocketRequestLogTest {
     WebsocketRequestLoggerFactory requestLoggerFactory = new WebsocketRequestLoggerFactory();
     requestLoggerFactory.appenders = List.of(new ListAppenderFactory<>(listAppender));
 
+    Locale.setDefault(Locale.US);
     WebsocketRequestLog requestLog = requestLoggerFactory.build("test-logger");
     ContainerRequest    request    = new ContainerRequest (null, URI.create("/v1/test"), "GET", new WebSocketSecurityContext(new ContextPrincipal(sessionContext)), new MapPropertiesDelegate(new HashMap<>()), null);
     request.header("User-Agent", "SmertZeSmert");

--- a/websocket-resources/src/test/java/org/whispersystems/websocket/logging/WebSocketRequestLogTest.java
+++ b/websocket-resources/src/test/java/org/whispersystems/websocket/logging/WebSocketRequestLogTest.java
@@ -41,6 +41,7 @@ public class WebSocketRequestLogTest {
     WebsocketRequestLog requestLog = requestLoggerFactory.build("test-logger");
     ContainerRequest    request    = new ContainerRequest (null, URI.create("/v1/test"), "GET", new WebSocketSecurityContext(new ContextPrincipal(sessionContext)), new MapPropertiesDelegate(new HashMap<>()), null);
     ContainerResponse   response   = new ContainerResponse(request, Response.ok("My response body").build());
+
     requestLog.log("123.456.789.123", request, response);
 
     listAppender.waitForListSize(1);

--- a/websocket-resources/src/test/java/org/whispersystems/websocket/logging/WebSocketRequestLogTest.java
+++ b/websocket-resources/src/test/java/org/whispersystems/websocket/logging/WebSocketRequestLogTest.java
@@ -11,6 +11,7 @@ import io.dropwizard.logging.AbstractOutputStreamAppenderFactory;
 import org.glassfish.jersey.internal.MapPropertiesDelegate;
 import org.glassfish.jersey.server.ContainerRequest;
 import org.glassfish.jersey.server.ContainerResponse;
+import org.junit.Before;
 import org.junit.Test;
 import org.whispersystems.websocket.WebSocketSecurityContext;
 import org.whispersystems.websocket.session.ContextPrincipal;
@@ -29,6 +30,11 @@ import static org.mockito.Mockito.mock;
 
 public class WebSocketRequestLogTest {
 
+  @Before
+  public void beforeEachTest() {
+    Locale.setDefault(Locale.US);
+  }
+
   @Test
   public void testLogLineWithoutHeaders() throws InterruptedException {
     WebSocketSessionContext sessionContext = mock(WebSocketSessionContext.class);
@@ -37,7 +43,6 @@ public class WebSocketRequestLogTest {
     WebsocketRequestLoggerFactory requestLoggerFactory = new WebsocketRequestLoggerFactory();
     requestLoggerFactory.appenders = List.of(new ListAppenderFactory<>(listAppender));
 
-    Locale.setDefault(Locale.US);
     WebsocketRequestLog requestLog = requestLoggerFactory.build("test-logger");
     ContainerRequest    request    = new ContainerRequest (null, URI.create("/v1/test"), "GET", new WebSocketSecurityContext(new ContextPrincipal(sessionContext)), new MapPropertiesDelegate(new HashMap<>()), null);
     ContainerResponse   response   = new ContainerResponse(request, Response.ok("My response body").build());
@@ -59,7 +64,6 @@ public class WebSocketRequestLogTest {
     WebsocketRequestLoggerFactory requestLoggerFactory = new WebsocketRequestLoggerFactory();
     requestLoggerFactory.appenders = List.of(new ListAppenderFactory<>(listAppender));
 
-    Locale.setDefault(Locale.US);
     WebsocketRequestLog requestLog = requestLoggerFactory.build("test-logger");
     ContainerRequest    request    = new ContainerRequest (null, URI.create("/v1/test"), "GET", new WebSocketSecurityContext(new ContextPrincipal(sessionContext)), new MapPropertiesDelegate(new HashMap<>()), null);
     request.header("User-Agent", "SmertZeSmert");

--- a/websocket-resources/src/test/java/org/whispersystems/websocket/logging/WebSocketRequestLogTest.java
+++ b/websocket-resources/src/test/java/org/whispersystems/websocket/logging/WebSocketRequestLogTest.java
@@ -11,6 +11,7 @@ import io.dropwizard.logging.AbstractOutputStreamAppenderFactory;
 import org.glassfish.jersey.internal.MapPropertiesDelegate;
 import org.glassfish.jersey.server.ContainerRequest;
 import org.glassfish.jersey.server.ContainerResponse;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.whispersystems.websocket.WebSocketSecurityContext;
@@ -30,9 +31,16 @@ import static org.mockito.Mockito.mock;
 
 public class WebSocketRequestLogTest {
 
+  private final static Locale ORIGINAL_DEFAULT_LOCALE = Locale.getDefault();
+
   @Before
   public void beforeEachTest() {
-    Locale.setDefault(Locale.US);
+    Locale.setDefault(Locale.ENGLISH);
+  }
+
+  @After
+  public void afterEachTest() {
+    Locale.setDefault(ORIGINAL_DEFAULT_LOCALE);
   }
 
   @Test


### PR DESCRIPTION
# Problem
In `WebSocketRequestLogTest.java`, unit tests `testLogLineWithoutHeaders()` and `testLogLineWithHeaders()` fail the date regex matching when the default Locale of the developer's machine is `Locale.CANADA`. When the default Locale is `Locale.CANADA`, then the formatted date for `dd/MMM/yyyy:HH:mm:ss Z` has an extra period after the month, e.g., `24/Jul./2021:21:27:53 -0400`.  This does not match the regex `[0-9]{2}\/[a-zA-Z]{3}\/[0-9]{4}:[0-9]{2}:[0-9]{2}:[0-9]{2} (\-|\+)[0-9]{4}`, which expects the month to have only three letters.

## Reproducing the problem

If you want to reproduce the problem on a US machine, add `Locale.setDefault(Locale.CANADA);` at the beginning of the unit test(s) to simulate a machine with a non-US default Locale.

# Fix
Set the default locale to `Locale.US` before the Junit tests.