### PR TITLE
Pin 3rd-party Actions dependency by full git SHA

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@3bc31aaf88e8fc94dc1e632d48af61be5ca8721c
         with:
           distribution: 'adopt'
           java-version: 11


### PR DESCRIPTION
This change follows GitHub's security-hardening guidance. By pinning to a full SHA, we reduce our exposure to supply-chain attacks where a malicious party could compromise the 3rd-party Actions repo, commit malicious code, and then mutate an existing git tag to redirect to a SHA containing the malicious commit.

See https://docs.github.com/en/actions/learn-github-actions/security-hardening-for-github-actions#using-third-party-actions for more.