### PR TITLE
Fix merge issue with "Retire AmbiguousIdentifier" commit

### DIFF
--- a/service/src/test/java/org/whispersystems/textsecuregcm/tests/controllers/PaymentsControllerTest.java
+++ b/service/src/test/java/org/whispersystems/textsecuregcm/tests/controllers/PaymentsControllerTest.java
@@ -123,7 +123,7 @@ class PaymentsControllerTest {
         resources.getJerseyTest()
             .target("/v1/payments/conversions")
             .request()
-            .header("Authorization", AuthHelper.getAuthHeader(AuthHelper.VALID_NUMBER, AuthHelper.VALID_PASSWORD))
+            .header("Authorization", AuthHelper.getAuthHeader(AuthHelper.VALID_UUID, AuthHelper.VALID_PASSWORD))
             .get(String.class);
 
     assertThat(json.contains("{\"USD\":2.35,\"EUR\":1.89}"));


### PR DESCRIPTION
In the Aug 15 commit, [`getAuthHeader(String identifier, String password)` was changed to private visibility](https://github.com/signalapp/Signal-Server/commit/d1735c7e57c4111516cbdc8a6ca69eaf73cf8290#diff-999d2d4cdafe62b37094580b0cad114c7225ca8d72ee0a6947760d0a9befb243L190), and `getAuthHeader(UUID uuid, String password)` was exposed instead, causing compilation error with Aug 1 ['BigDecimal' change](https://github.com/signalapp/Signal-Server/pull/134).

This fixes the merge issue.