### PR TITLE
Fix Authorization header format validation to match RFC HTTP header specifications

### DIFF
--- a/service/src/test/java/org/whispersystems/textsecuregcm/auth/BasicAuthorizationHeaderTest.java
+++ b/service/src/test/java/org/whispersystems/textsecuregcm/auth/BasicAuthorizationHeaderTest.java
@@ -30,6 +30,24 @@ class BasicAuthorizationHeaderTest {
     }
 
     {
+      final BasicAuthorizationHeader header =
+          BasicAuthorizationHeader.fromString(" Basic YWxhZGRpbjpvcGVuc2VzYW1l ");
+
+      assertEquals("aladdin", header.getUsername());
+      assertEquals("opensesame", header.getPassword());
+      assertEquals(Device.MASTER_ID, header.getDeviceId());
+    }
+
+    {
+      final BasicAuthorizationHeader header =
+          BasicAuthorizationHeader.fromString("  Basic  YWxhZGRpbjpvcGVuc2VzYW1l  ");
+
+      assertEquals("aladdin", header.getUsername());
+      assertEquals("opensesame", header.getPassword());
+      assertEquals(Device.MASTER_ID, header.getDeviceId());
+    }
+
+    {
       final BasicAuthorizationHeader header = BasicAuthorizationHeader.fromString("Basic " +
           Base64.getEncoder().encodeToString("username.7:password".getBytes(StandardCharsets.UTF_8)));
 

--- a/service/src/test/java/org/whispersystems/textsecuregcm/auth/BasicAuthorizationHeaderTest.java
+++ b/service/src/test/java/org/whispersystems/textsecuregcm/auth/BasicAuthorizationHeaderTest.java
@@ -73,6 +73,7 @@ class BasicAuthorizationHeaderTest {
         "Digest YWxhZGRpbjpvcGVuc2VzYW1l",
         "Basic",
         "Basic ",
+        "BasicYWxhZGRpbjpvcGVuc2VzYW1l",
         "Basic &&&&&&",
         "Basic " + Base64.getEncoder().encodeToString("".getBytes(StandardCharsets.UTF_8)),
         "Basic " + Base64.getEncoder().encodeToString(":".getBytes(StandardCharsets.UTF_8)),


### PR DESCRIPTION
According to [RFC 2616](https://datatracker.ietf.org/doc/html/rfc2616#section-4.2), HTTP header values may have leading and trailing whitespace.

This fix may or may not address the 401 Unauthorized response in https://github.com/signalapp/Signal-iOS/issues/5114 . (I do not own a Mac to be able to run iOS app version 3.9.0 in Xcode Simulator in debug mode, in order to reproduce the issue.) Either way, HTTP clients may implement the Authorization header values according to the RFC spec with leading or trailing whitespace.

Please comment on https://github.com/signalapp/Signal-iOS/issues/5114 if/when this fix is deployed in production.  An important Signal contact of mine cannot access years of Signal messages on their old iPhone that can only run iOS 10, which is only supported up to app version 3.9.0. These messages contain important data such as passwords to accounts, photos, and messages to reconstruct a sequence of events that occurred in the past.