### PR TITLE
Update libphonenumber to 8.12.48

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     <jaxb.version>2.3.1</jaxb.version>
     <jedis.version>2.9.0</jedis.version>
     <lettuce.version>6.0.4.RELEASE</lettuce.version>
-    <libphonenumber.version>8.12.45</libphonenumber.version>
+    <libphonenumber.version>8.12.48</libphonenumber.version>
     <logstash.logback.version>7.0.1</logstash.logback.version>
     <micrometer.version>1.5.3</micrometer.version>
     <mockito.version>4.3.1</mockito.version>


### PR DESCRIPTION
Updates libphonenumber to 8.12.48

Solves [#9005](https://github.com/signalapp/Signal-Android/issues/9005) from Signal Android.
See also Signal Android PR [#12228](https://github.com/signalapp/Signal-Android/pull/12228) for more details.