### PR TITLE
[Draft/Untested] Replace reserved "notification" key with "newMessageAlert" in FcmSender

### DIFF
--- a/service/src/main/java/org/whispersystems/textsecuregcm/push/FcmSender.java
+++ b/service/src/main/java/org/whispersystems/textsecuregcm/push/FcmSender.java
@@ -88,7 +88,7 @@ public class FcmSender implements PushNotificationSender {
             .build());
 
     final String key = switch (pushNotification.notificationType()) {
-      case NOTIFICATION -> "notification";
+      case NOTIFICATION -> "newMessageAlert";
       case ATTEMPT_LOGIN_NOTIFICATION_HIGH_PRIORITY, ATTEMPT_LOGIN_NOTIFICATION_LOW_PRIORITY -> "attemptLoginContext";
       case CHALLENGE -> "challenge";
       case RATE_LIMIT_CHALLENGE -> "rateLimitChallenge";


### PR DESCRIPTION
I am troubleshooting some bugs with Android notification delivery when Data Saver mode is on. I think the root cause actually comes back to this server code. 

# Reproduction Steps
The reproduction steps for one of the failures I have found is: 

1. Turn on Data Saver Mode on Android
2. Set your WiFi connection to "Metered" 
3. Send a message to the phone in Data Saver mode
4. Wait for the notification for the message to be delivered. 
5. Call the phone in Data Saver mode

**Observed Behavior** The phone in Data Saver mode will not ring, or will only ring after a long delay.
**Expected Behavior** The phone should ring immediately. 

# Change Suggested
In the FCM documentation, it is [documented](https://firebase.google.com/docs/cloud-messaging/concept-options) that: 

> Make sure that you do not use any reserved words in your custom key-value pairs. Reserved words include "from", "notification," "message_type", or any word starting with "google" or "gcm."

So the server should definitely not use this particular key either way. Luckily, the [Android client is written such that this key](https://github.com/signalapp/Signal-Android/blob/main/app/src/main/java/org/thoughtcrime/securesms/gcm/FcmReceiveService.java#L47) can change in a backwards compatible manner. 

# Theoretical Connection to Buggy Behavior
My operating theory is that this is leading to a notification delivery errors/delays on Android because FCM is treating these messages as collapsible, and thus enforcing the [once message per three minute](https://firebase.google.com/docs/cloud-messaging/concept-options#collapsible_throttling) throttle meant for collapsible messages. 

It is documented on that same page that: 

> Topic messages with no payload are collapsible by default. Notification messages are always collapsible and will ignore the collapse_key parameter.

Will just including a notification key in the data dictionary rather than in the root object dictionary cause FCM to treat this message as collapsible? [¯\_(ツ)_/¯](https://stackoverflow.com/questions/68707571/data-messages-vs-notification-messages-collapsible-and-non-collapsible-confusi)  

# Testing Status
I have *not* tested this change (yet). I need to get the Signal server setup and running in a personal development environment first, and that will take a little effort. I wanted to collect my thoughts here and get some feedback before I went that next step. 